### PR TITLE
update for new trading 212 api

### DIFF
--- a/Trading212.lua
+++ b/Trading212.lua
@@ -304,8 +304,8 @@ function PieToPortfolio(pie_info)
         -- currencyOfPurchasePrice = instr["currencyCode"],
         -- price = v["currentPrice"],
         -- currencyOfPrice = instr["currencyCode"],
-        amount = v["result"]["value"],
-        originalAmount = v["result"]["investedValue"],
+        amount = v["result"]["priceAvgValue"],
+        originalAmount = v["result"]["priceAvgInvestedValue"],
         -- currencyOfOriginalAmount = instr["currencyCode"],
         -- tradeTimestamp = IsotimeToUnixtime(v["initialFillDate"]),
       }


### PR DESCRIPTION
Trading 212 changed the response for pies very slightly, this PR uses the new value-keys. This fixes #2.

Note that I didn't update the signature because obviously I can't do that. If anyone wants to use this version of the script before a real update is released, you would need to do three things:

1. Open MoneyMoney, go to settings, disable Extensions > "Verify digital signatures of extensions"
2. Open Help > Show Database in Finder
3. Edit Extensions/Trading212.lua: First, copy over the two lines changed, then remove the last line that reads "-- SIGNATURE: ..."

Now re-fetch your trading 212 account and all pies should work again.